### PR TITLE
feat: add support for OCI backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Support for the [Module Registry Protocol](https://www.terraform.io/internals/mo
 * Provider Registry
 * Network mirror for providers
 * Pull-through mirror for providers
-* Support for S3, GCS, Azure Blob Storage, and MinIO object storage
+* Support for S3, GCS, Azure Blob Storage, MinIO object storage, and OCI registries
 * Support for OIDC and static API token authorization
 
 ## Installation

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,6 +44,14 @@ var (
 	flagAzureStorageContainer       string
 	flagAzureStoragePrefix          string
 	flagAzureStorageSignedURLExpiry time.Duration
+
+	// OCI Registry options
+	flagOCIRegistry    string
+	flagOCIRepository  string
+	flagOCIUsername    string
+	flagOCIPassword    string
+	flagOCIToken       string
+	flagOCIInsecure    bool
 )
 
 var rootCmd = &cobra.Command{
@@ -90,6 +98,12 @@ For GCS presigned URLs this SA needs the iam.serviceAccountTokenCreator role.`)
 	rootCmd.PersistentFlags().StringVar(&flagAzureStorageContainer, "storage-azure-container", "", "Azure Storage Container to use for the registry")
 	rootCmd.PersistentFlags().StringVar(&flagAzureStoragePrefix, "storage-azure-prefix", "", "Azure Storage prefix to use for the registry")
 	rootCmd.PersistentFlags().DurationVar(&flagAzureStorageSignedURLExpiry, "storage-azure-signedurl-expiry", 5*time.Minute, "Generate Azure Storage signed URL valid for X seconds.")
+	rootCmd.PersistentFlags().StringVar(&flagOCIRegistry, "storage-oci-registry", "", "OCI registry hostname to use for the registry")
+	rootCmd.PersistentFlags().StringVar(&flagOCIRepository, "storage-oci-repository", "", "OCI repository path to use for the registry")
+	rootCmd.PersistentFlags().StringVar(&flagOCIUsername, "storage-oci-username", "", "OCI registry username for authentication")
+	rootCmd.PersistentFlags().StringVar(&flagOCIPassword, "storage-oci-password", "", "OCI registry password for authentication")
+	rootCmd.PersistentFlags().StringVar(&flagOCIToken, "storage-oci-token", "", "OCI registry token for authentication")
+	rootCmd.PersistentFlags().BoolVar(&flagOCIInsecure, "storage-oci-insecure", false, "Allow insecure connections to OCI registry")
 }
 
 func initializeConfig(cmd *cobra.Command) error {
@@ -145,6 +159,15 @@ func setupStorage(ctx context.Context) (storage.Storage, error) {
 			storage.WithAzureStoragePrefix(flagAzureStoragePrefix),
 			storage.WithAzureStorageArchiveFormat(flagModuleArchiveFormat),
 			storage.WithAzureStorageSignedUrlExpiry(flagAzureStorageSignedURLExpiry),
+		)
+	case flagOCIRegistry != "":
+		return storage.NewOCIStorage(ctx,
+			flagOCIRegistry,
+			flagOCIRepository,
+			storage.WithOCIUsername(flagOCIUsername),
+			storage.WithOCIPassword(flagOCIPassword),
+			storage.WithOCIToken(flagOCIToken),
+			storage.WithOCIInsecure(flagOCIInsecure),
 		)
 	default:
 		return nil, errors.New("storage provider is not specified")

--- a/docs/configuration/storage-backends/oci.md
+++ b/docs/configuration/storage-backends/oci.md
@@ -1,0 +1,122 @@
+# OCI Registry
+
+## Authorization
+
+The boring-registry needs to authenticate with your OCI-compatible container registry. This can be achieved through:
+
+1. **Environment Variables**: Set the `OCI_REGISTRY_USERNAME` and `OCI_REGISTRY_PASSWORD` environment variables for basic authentication
+2. **Registry Token**: Use `OCI_REGISTRY_TOKEN` for token-based authentication
+3. **Docker Config**: The registry client will also check standard Docker configuration files (`~/.docker/config.json`)
+
+For public registries like Docker Hub, you might not need authentication for pulling artifacts.
+
+## Configuration for OCI Registry
+
+The following configuration options are available:
+
+|Flag|Environment Variable|Description|
+|---|---|---|
+|`--storage-oci-registry`|`BORING_REGISTRY_STORAGE_OCI_REGISTRY`|OCI registry hostname (e.g., registry.example.com)|
+|`--storage-oci-repository`|`BORING_REGISTRY_STORAGE_OCI_REPOSITORY`|Base repository path in the registry (e.g., boring-registry)|
+|`--storage-oci-username`|`BORING_REGISTRY_STORAGE_OCI_USERNAME` or `OCI_REGISTRY_USERNAME`|Username for registry authentication (optional)|
+|`--storage-oci-password`|`BORING_REGISTRY_STORAGE_OCI_PASSWORD` or `OCI_REGISTRY_PASSWORD`|Password for registry authentication (optional)|
+|`--storage-oci-token`|`BORING_REGISTRY_STORAGE_OCI_TOKEN` or `OCI_REGISTRY_TOKEN`|Token for registry authentication (optional)|
+|`--storage-oci-insecure`|`BORING_REGISTRY_STORAGE_OCI_INSECURE`|Allow insecure connections to the registry (default false)|
+
+## OCI Registry Layout
+
+The OCI storage backend organizes Terraform modules and providers using a structured repository layout:
+
+### Modules
+- **Path**: `{registry}/{repository}/modules/{namespace}/{name}/{provider}:{namespace}-{name}-{provider}-{version}`
+- **Example**: `registry.example.com/boring-registry/modules/hashicorp/consul/aws:hashicorp-consul-aws-1.0.0`
+
+### Providers
+- **Provider Package**: `{registry}/{repository}/providers/{namespace}/{name}:terraform-provider-{name}_{version}_{os}_{arch}.zip`
+- **SHA256SUMS**: `{registry}/{repository}/providers/{namespace}/{name}:terraform-provider-{name}_{version}_SHA256SUMS`
+- **SHA256SUMS Signature**: `{registry}/{repository}/providers/{namespace}/{name}:terraform-provider-{name}_{version}_SHA256SUMS.sig`
+- **Signing Keys**: `{registry}/{repository}/providers/{namespace}:signing-keys.json`
+
+### Mirrored Providers
+- **Provider Package**: `{registry}/{repository}/mirror/providers/{hostname}/{namespace}/{name}:terraform-provider-{name}_{version}_{os}_{arch}.zip`
+- **SHA256SUMS**: `{registry}/{repository}/mirror/providers/{hostname}/{namespace}/{name}:terraform-provider-{name}_{version}_SHA256SUMS`
+- **SHA256SUMS Signature**: `{registry}/{repository}/mirror/providers/{hostname}/{namespace}/{name}:terraform-provider-{name}_{version}_SHA256SUMS.sig`
+- **Signing Keys**: `{registry}/{repository}/mirror/providers/{hostname}/{namespace}:signing-keys.json`
+
+## Examples
+
+The following shows a minimal example to run `boring-registry server` with an OCI registry:
+
+```console
+$ boring-registry server \
+  --storage-oci-registry=registry.example.com \
+  --storage-oci-repository=boring-registry
+```
+
+### Using Docker Hub
+
+```console
+$ boring-registry server \
+  --storage-oci-registry=docker.io \
+  --storage-oci-repository=myorg/boring-registry \
+  --storage-oci-username=myusername \
+  --storage-oci-password=mypassword
+```
+
+### Using a Private Registry with Token Authentication
+
+```console
+$ boring-registry server \
+  --storage-oci-registry=private-registry.company.com \
+  --storage-oci-repository=terraform/boring-registry \
+  --storage-oci-token=myregistrytoken
+```
+
+### Using Harbor Registry
+
+```console
+$ boring-registry server \
+  --storage-oci-registry=harbor.company.com \
+  --storage-oci-repository=terraform/boring-registry \
+  --storage-oci-username=admin \
+  --storage-oci-password=Harbor12345
+```
+
+## Supported OCI Registries
+
+The OCI storage backend is compatible with any OCI-compliant container registry, including:
+
+- **Docker Hub**
+- **Harbor**
+- **Azure Container Registry (ACR)**
+- **Amazon Elastic Container Registry (ECR)**
+- **Google Container Registry (GCR)**
+- **GitHub Container Registry (GHCR)**
+- **GitLab Container Registry**
+- **JFrog Artifactory**
+- **Sonatype Nexus Repository**
+
+## Security Considerations
+
+- Always use HTTPS in production environments (avoid `--storage-oci-insecure`)
+- Use token-based authentication when available, as it's generally more secure than username/password
+- Consider using dedicated service accounts with minimal required permissions
+- Regularly rotate authentication credentials
+- Monitor registry access logs for unauthorized activity
+
+## Troubleshooting
+
+### Authentication Issues
+- Verify that your credentials are correct
+- Check that the user has push/pull permissions for the repository
+- Ensure the registry supports the authentication method you're using
+
+### Network Issues
+- Verify that the registry hostname is reachable
+- Check firewall rules if using a private registry
+- Use `--storage-oci-insecure` only for testing with self-signed certificates
+
+### Repository Access
+- Ensure the repository exists and is accessible
+- Check that you have the necessary permissions to create repositories if they don't exist
+- Verify the repository naming follows OCI standards

--- a/pkg/storage/oci.go
+++ b/pkg/storage/oci.go
@@ -1,0 +1,649 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/boring-registry/boring-registry/pkg/core"
+	"github.com/boring-registry/boring-registry/pkg/module"
+)
+
+// ociClientAPI is used to mock the OCI APIs for testing
+type ociClientAPI interface {
+	ArtifactExists(ctx context.Context, reference string) (bool, error)
+	DownloadArtifact(ctx context.Context, reference string) ([]byte, error)
+	UploadArtifact(ctx context.Context, reference string, content io.Reader, overwrite bool) error
+	ListTags(ctx context.Context, repository string, callback func(tags []string) error) error
+	GenerateDownloadURL(ctx context.Context, reference string) (string, error)
+}
+
+// OCIStorage is a Storage implementation backed by OCI Registry.
+// OCIStorage implements module.Storage, provider.Storage, and mirror.Storage
+type OCIStorage struct {
+	client              ociClientAPI
+	registry            string
+	repository          string
+	repositoryPrefix    string
+	username            string
+	password            string
+	token               string
+	insecure            bool
+	moduleArchiveFormat string
+	signedURLExpiry     time.Duration
+	httpClient          *http.Client
+}
+
+// GetModule retrieves information about a module from the OCI storage.
+func (s *OCIStorage) GetModule(ctx context.Context, namespace, name, provider, version string) (core.Module, error) {
+	ref := s.buildModuleReference(namespace, name, provider, version)
+	
+	exists, err := s.client.ArtifactExists(ctx, ref)
+	if err != nil {
+		return core.Module{}, err
+	} else if !exists {
+		return core.Module{}, module.ErrModuleNotFound
+	}
+
+	downloadURL, err := s.client.GenerateDownloadURL(ctx, ref)
+	if err != nil {
+		return core.Module{}, err
+	}
+
+	return core.Module{
+		Namespace:   namespace,
+		Name:        name,
+		Provider:    provider,
+		Version:     version,
+		DownloadURL: downloadURL,
+	}, nil
+}
+
+func (s *OCIStorage) ListModuleVersions(ctx context.Context, namespace, name, provider string) ([]core.Module, error) {
+	repoRef := s.buildModuleRepositoryReference(namespace, name, provider)
+	
+	var modules []core.Module
+	
+	err := s.client.ListTags(ctx, repoRef, func(tags []string) error {
+		for _, tag := range tags {
+			if strings.HasPrefix(tag, fmt.Sprintf("%s-%s-%s-", namespace, name, provider)) {
+				version := strings.TrimPrefix(tag, fmt.Sprintf("%s-%s-%s-", namespace, name, provider))
+				
+				downloadURL, err := s.client.GenerateDownloadURL(ctx, fmt.Sprintf("%s:%s", repoRef, tag))
+				if err != nil {
+					return err
+				}
+				
+				modules = append(modules, core.Module{
+					Namespace:   namespace,
+					Name:        name,
+					Provider:    provider,
+					Version:     version,
+					DownloadURL: downloadURL,
+				})
+			}
+		}
+		return nil
+	})
+	
+	if err != nil {
+		return nil, fmt.Errorf("%v: %w", module.ErrModuleListFailed, err)
+	}
+
+	return modules, nil
+}
+
+// UploadModule uploads a module to the OCI storage.
+func (s *OCIStorage) UploadModule(ctx context.Context, namespace, name, provider, version string, body io.Reader) (core.Module, error) {
+	if namespace == "" {
+		return core.Module{}, fmt.Errorf("namespace not defined")
+	}
+
+	if name == "" {
+		return core.Module{}, fmt.Errorf("name not defined")
+	}
+
+	if provider == "" {
+		return core.Module{}, fmt.Errorf("provider not defined")
+	}
+
+	if version == "" {
+		return core.Module{}, fmt.Errorf("version not defined")
+	}
+
+	ref := s.buildModuleReference(namespace, name, provider, version)
+
+	if _, err := s.GetModule(ctx, namespace, name, provider, version); err == nil {
+		return core.Module{}, fmt.Errorf("%w: %s", module.ErrModuleAlreadyExists, ref)
+	}
+
+	if err := s.client.UploadArtifact(ctx, ref, body, false); err != nil {
+		return core.Module{}, fmt.Errorf("%v: %w", module.ErrModuleUploadFailed, err)
+	}
+
+	return s.GetModule(ctx, namespace, name, provider, version)
+}
+
+// GetProvider retrieves information about a provider from the OCI storage.
+func (s *OCIStorage) getProvider(ctx context.Context, pt providerType, provider *core.Provider) (*core.Provider, error) {
+	var ref string
+	if pt == internalProviderType {
+		ref = s.buildInternalProviderReference(provider.Namespace, provider.Name, provider.Version, provider.OS, provider.Arch)
+	} else if pt == mirrorProviderType {
+		ref = s.buildMirrorProviderReference(provider.Hostname, provider.Namespace, provider.Name, provider.Version, provider.OS, provider.Arch)
+	}
+
+	exists, err := s.client.ArtifactExists(ctx, ref)
+	if err != nil {
+		return nil, err
+	} else if !exists {
+		return nil, noMatchingProviderFound(provider)
+	}
+
+	// Generate download URLs for provider artifacts
+	provider.DownloadURL, err = s.client.GenerateDownloadURL(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	
+	shasumRef := s.buildShasumReference(pt, provider.Hostname, provider.Namespace, provider.Name, provider.Version)
+	provider.SHASumsURL, err = s.client.GenerateDownloadURL(ctx, shasumRef)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate download url for %s: %w", shasumRef, err)
+	}
+	
+	shasumSigRef := s.buildShasumSignatureReference(pt, provider.Hostname, provider.Namespace, provider.Name, provider.Version)
+	provider.SHASumsSignatureURL, err = s.client.GenerateDownloadURL(ctx, shasumSigRef)
+	if err != nil {
+		return nil, err
+	}
+
+	// Download and parse shasum
+	shasumBytes, err := s.client.DownloadArtifact(ctx, shasumRef)
+	if err != nil {
+		return nil, err
+	}
+
+	provider.Shasum, err = readSHASums(bytes.NewReader(shasumBytes), s.buildProviderArchiveFilename(provider.Name, provider.Version, provider.OS, provider.Arch))
+	if err != nil {
+		return nil, err
+	}
+
+	var signingKeys *core.SigningKeys
+	if pt == internalProviderType {
+		signingKeys, err = s.SigningKeys(ctx, provider.Namespace)
+	} else if pt == mirrorProviderType {
+		signingKeys, err = s.MirroredSigningKeys(ctx, provider.Hostname, provider.Namespace)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	provider.Filename = s.buildProviderArchiveFilename(provider.Name, provider.Version, provider.OS, provider.Arch)
+	provider.SigningKeys = *signingKeys
+	return provider, nil
+}
+
+func (s *OCIStorage) GetProvider(ctx context.Context, namespace, name, version, os, arch string) (*core.Provider, error) {
+	p, err := s.getProvider(ctx, internalProviderType, &core.Provider{
+		Namespace: namespace,
+		Name:      name,
+		Version:   version,
+		OS:        os,
+		Arch:      arch,
+	})
+
+	return p, err
+}
+
+func (s *OCIStorage) GetMirroredProvider(ctx context.Context, provider *core.Provider) (*core.Provider, error) {
+	return s.getProvider(ctx, mirrorProviderType, provider)
+}
+
+func (s *OCIStorage) listProviderVersions(ctx context.Context, pt providerType, provider *core.Provider) ([]*core.Provider, error) {
+	repoRef := s.buildProviderRepositoryReference(pt, provider.Hostname, provider.Namespace, provider.Name)
+	
+	var providers []*core.Provider
+	
+	err := s.client.ListTags(ctx, repoRef, func(tags []string) error {
+		for _, tag := range tags {
+			p, err := core.NewProviderFromArchive(tag)
+			if err != nil {
+				continue
+			}
+
+			if provider.Version != "" && provider.Version != p.Version {
+				// The provider version doesn't match the requested version
+				continue
+			}
+
+			p.Hostname = provider.Hostname
+			p.Namespace = provider.Namespace
+			
+			archiveUrl, err := s.client.GenerateDownloadURL(ctx, fmt.Sprintf("%s:%s", repoRef, tag))
+			if err != nil {
+				return err
+			}
+			p.DownloadURL = archiveUrl
+
+			providers = append(providers, &p)
+		}
+		return nil
+	})
+	
+	if err != nil {
+		return nil, fmt.Errorf("failed to list provider versions: %w", err)
+	}
+
+	if len(providers) == 0 {
+		return nil, noMatchingProviderFound(provider)
+	}
+
+	return providers, nil
+}
+
+func (s *OCIStorage) ListProviderVersions(ctx context.Context, namespace, name string) (*core.ProviderVersions, error) {
+	providers, err := s.listProviderVersions(ctx, internalProviderType, &core.Provider{Namespace: namespace, Name: name})
+	if err != nil {
+		return nil, err
+	}
+
+	collection := NewCollection()
+	for _, p := range providers {
+		collection.Add(p)
+	}
+	return collection.List(), nil
+}
+
+func (s *OCIStorage) ListMirroredProviders(ctx context.Context, provider *core.Provider) ([]*core.Provider, error) {
+	return s.listProviderVersions(ctx, mirrorProviderType, provider)
+}
+
+func (s *OCIStorage) UploadProviderReleaseFiles(ctx context.Context, namespace, name, filename string, file io.Reader) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace argument is empty")
+	}
+
+	if name == "" {
+		return fmt.Errorf("name argument is empty")
+	}
+
+	if filename == "" {
+		return fmt.Errorf("filename argument is empty")
+	}
+
+	ref := s.buildProviderReleaseFileReference(namespace, name, filename)
+	
+	// Check if artifact already exists when not overwriting
+	exists, err := s.client.ArtifactExists(ctx, ref)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return fmt.Errorf("failed to upload %s: %w", ref, core.ErrObjectAlreadyExists)
+	}
+	
+	return s.client.UploadArtifact(ctx, ref, file, false)
+}
+
+func (s *OCIStorage) signingKeys(ctx context.Context, pt providerType, hostname, namespace string) (*core.SigningKeys, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace argument is empty")
+	}
+	
+	ref := s.buildSigningKeysReference(pt, hostname, namespace)
+	exists, err := s.client.ArtifactExists(ctx, ref)
+	if err != nil {
+		return nil, err
+	} else if !exists {
+		return nil, core.ErrObjectNotFound
+	}
+
+	signingKeysRaw, err := s.client.DownloadArtifact(ctx, ref)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download signing_keys.json for namespace %s: %w", namespace, err)
+	}
+
+	return unmarshalSigningKeys(signingKeysRaw)
+}
+
+// SigningKeys downloads the JSON placed in the namespace in OCI registry and unmarshals it into a core.SigningKeys
+func (s *OCIStorage) SigningKeys(ctx context.Context, namespace string) (*core.SigningKeys, error) {
+	return s.signingKeys(ctx, internalProviderType, "", namespace)
+}
+
+func (s *OCIStorage) MirroredSigningKeys(ctx context.Context, hostname, namespace string) (*core.SigningKeys, error) {
+	return s.signingKeys(ctx, mirrorProviderType, hostname, namespace)
+}
+
+func (s *OCIStorage) uploadSigningKeys(ctx context.Context, pt providerType, hostname, namespace string, signingKeys *core.SigningKeys) error {
+	b, err := json.Marshal(signingKeys)
+	if err != nil {
+		return err
+	}
+	
+	ref := s.buildSigningKeysReference(pt, hostname, namespace)
+	return s.client.UploadArtifact(ctx, ref, bytes.NewReader(b), true)
+}
+
+func (s *OCIStorage) UploadMirroredSigningKeys(ctx context.Context, hostname, namespace string, signingKeys *core.SigningKeys) error {
+	return s.uploadSigningKeys(ctx, mirrorProviderType, hostname, namespace, signingKeys)
+}
+
+func (s *OCIStorage) MirroredSha256Sum(ctx context.Context, provider *core.Provider) (*core.Sha256Sums, error) {
+	ref := s.buildShasumReference(mirrorProviderType, provider.Hostname, provider.Namespace, provider.Name, provider.Version)
+	shaSumBytes, err := s.client.DownloadArtifact(ctx, ref)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download SHA256SUMS: %w", err)
+	}
+
+	return core.NewSha256Sums(provider.ShasumFileName(), bytes.NewReader(shaSumBytes))
+}
+
+func (s *OCIStorage) UploadMirroredFile(ctx context.Context, provider *core.Provider, fileName string, reader io.Reader) error {
+	ref := s.buildMirroredFileReference(provider.Hostname, provider.Namespace, provider.Name, fileName)
+	return s.client.UploadArtifact(ctx, ref, reader, true)
+}
+
+func (s *OCIStorage) GetDownloadUrl(ctx context.Context, url string) (string, error) {
+	return url, nil
+}
+
+// Helper methods for building OCI references
+func (s *OCIStorage) buildModuleReference(namespace, name, provider, version string) string {
+	tag := fmt.Sprintf("%s-%s-%s-%s", namespace, name, provider, version)
+	return fmt.Sprintf("%s/%s/modules/%s:%s", s.registry, s.buildRepositoryPath(), s.buildModulePath(namespace, name, provider), tag)
+}
+
+func (s *OCIStorage) buildModuleRepositoryReference(namespace, name, provider string) string {
+	return fmt.Sprintf("%s/%s/modules/%s", s.registry, s.buildRepositoryPath(), s.buildModulePath(namespace, name, provider))
+}
+
+func (s *OCIStorage) buildModulePath(namespace, name, provider string) string {
+	return fmt.Sprintf("%s/%s/%s", namespace, name, provider)
+}
+
+func (s *OCIStorage) buildInternalProviderReference(namespace, name, version, os, arch string) string {
+	filename := s.buildProviderArchiveFilename(name, version, os, arch)
+	return fmt.Sprintf("%s/%s/providers/%s/%s:%s", s.registry, s.buildRepositoryPath(), namespace, name, filename)
+}
+
+func (s *OCIStorage) buildMirrorProviderReference(hostname, namespace, name, version, os, arch string) string {
+	filename := s.buildProviderArchiveFilename(name, version, os, arch)
+	return fmt.Sprintf("%s/%s/mirror/providers/%s/%s/%s:%s", s.registry, s.buildRepositoryPath(), hostname, namespace, name, filename)
+}
+
+func (s *OCIStorage) buildProviderRepositoryReference(pt providerType, hostname, namespace, name string) string {
+	if pt == internalProviderType {
+		return fmt.Sprintf("%s/%s/providers/%s/%s", s.registry, s.buildRepositoryPath(), namespace, name)
+	}
+	return fmt.Sprintf("%s/%s/mirror/providers/%s/%s/%s", s.registry, s.buildRepositoryPath(), hostname, namespace, name)
+}
+
+func (s *OCIStorage) buildProviderReleaseFileReference(namespace, name, filename string) string {
+	return fmt.Sprintf("%s/%s/providers/%s/%s:%s", s.registry, s.buildRepositoryPath(), namespace, name, filename)
+}
+
+func (s *OCIStorage) buildShasumReference(pt providerType, hostname, namespace, name, version string) string {
+	filename := fmt.Sprintf("terraform-provider-%s_%s_SHA256SUMS", name, version)
+	if pt == internalProviderType {
+		return fmt.Sprintf("%s/%s/providers/%s/%s:%s", s.registry, s.buildRepositoryPath(), namespace, name, filename)
+	}
+	return fmt.Sprintf("%s/%s/mirror/providers/%s/%s/%s:%s", s.registry, s.buildRepositoryPath(), hostname, namespace, name, filename)
+}
+
+func (s *OCIStorage) buildShasumSignatureReference(pt providerType, hostname, namespace, name, version string) string {
+	filename := fmt.Sprintf("terraform-provider-%s_%s_SHA256SUMS.sig", name, version)
+	if pt == internalProviderType {
+		return fmt.Sprintf("%s/%s/providers/%s/%s:%s", s.registry, s.buildRepositoryPath(), namespace, name, filename)
+	}
+	return fmt.Sprintf("%s/%s/mirror/providers/%s/%s/%s:%s", s.registry, s.buildRepositoryPath(), hostname, namespace, name, filename)
+}
+
+func (s *OCIStorage) buildSigningKeysReference(pt providerType, hostname, namespace string) string {
+	if pt == internalProviderType {
+		return fmt.Sprintf("%s/%s/providers/%s:signing-keys.json", s.registry, s.buildRepositoryPath(), namespace)
+	}
+	return fmt.Sprintf("%s/%s/mirror/providers/%s/%s:signing-keys.json", s.registry, s.buildRepositoryPath(), hostname, namespace)
+}
+
+func (s *OCIStorage) buildMirroredFileReference(hostname, namespace, name, filename string) string {
+	return fmt.Sprintf("%s/%s/mirror/providers/%s/%s/%s:%s", s.registry, s.buildRepositoryPath(), hostname, namespace, name, filename)
+}
+
+func (s *OCIStorage) buildProviderArchiveFilename(name, version, os, arch string) string {
+	return fmt.Sprintf("terraform-provider-%s_%s_%s_%s.zip", name, version, os, arch)
+}
+
+func (s *OCIStorage) buildRepositoryPath() string {
+	if s.repositoryPrefix != "" {
+		return fmt.Sprintf("%s/%s", s.repositoryPrefix, s.repository)
+	}
+	return s.repository
+}
+
+// OCIStorageOption provides additional options for the OCIStorage.
+type OCIStorageOption func(*OCIStorage)
+
+// WithOCIStorageRepositoryPrefix configures the OCI storage to work under a given repository prefix.
+func WithOCIStorageRepositoryPrefix(prefix string) OCIStorageOption {
+	return func(s *OCIStorage) {
+		s.repositoryPrefix = prefix
+	}
+}
+
+// WithOCIStorageCredentials configures the username and password for OCI registry authentication.
+func WithOCIStorageCredentials(username, password string) OCIStorageOption {
+	return func(s *OCIStorage) {
+		s.username = username
+		s.password = password
+	}
+}
+
+// WithOCIArchiveFormat configures the module archive format (zip, tar, tgz, etc.)
+func WithOCIArchiveFormat(archiveFormat string) OCIStorageOption {
+	return func(s *OCIStorage) {
+		s.moduleArchiveFormat = archiveFormat
+	}
+}
+
+// WithOCIStorageSignedUrlExpiry configures the duration until the signed url expires
+func WithOCIStorageSignedUrlExpiry(t time.Duration) OCIStorageOption {
+	return func(s *OCIStorage) {
+		s.signedURLExpiry = t
+	}
+}
+
+// WithOCIStorageHTTPClient configures a custom HTTP client for the OCI storage
+func WithOCIStorageHTTPClient(client *http.Client) OCIStorageOption {
+	return func(s *OCIStorage) {
+		s.httpClient = client
+	}
+}
+
+// WithOCIUsername configures the OCI registry username for authentication.
+func WithOCIUsername(username string) OCIStorageOption {
+	return func(s *OCIStorage) {
+		s.username = username
+	}
+}
+
+// WithOCIPassword configures the OCI registry password for authentication.
+func WithOCIPassword(password string) OCIStorageOption {
+	return func(s *OCIStorage) {
+		s.password = password
+	}
+}
+
+// WithOCIToken configures the OCI registry token for authentication.
+func WithOCIToken(token string) OCIStorageOption {
+	return func(s *OCIStorage) {
+		s.token = token
+	}
+}
+
+// WithOCIInsecure configures whether to allow insecure connections.
+func WithOCIInsecure(insecure bool) OCIStorageOption {
+	return func(s *OCIStorage) {
+		s.insecure = insecure
+	}
+}
+
+// NewOCIStorage returns a fully initialized OCI storage.
+func NewOCIStorage(ctx context.Context, registry, repository string, options ...OCIStorageOption) (Storage, error) {
+	// Required- and default-values should be set here
+	s := &OCIStorage{
+		registry:            registry,
+		repository:          repository,
+		moduleArchiveFormat: DefaultModuleArchiveFormat,
+		signedURLExpiry:     5 * time.Minute,
+		httpClient:          &http.Client{Timeout: 30 * time.Second},
+	}
+
+	for _, option := range options {
+		option(s)
+	}
+
+	// Create the OCI client
+	client, err := s.createOCIClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OCI client: %w", err)
+	}
+	
+	s.client = client
+
+	return s, nil
+}
+
+// createOCIClient creates an OCI client implementation
+func (s *OCIStorage) createOCIClient(ctx context.Context) (ociClientAPI, error) {
+	return &ociClient{
+		registry:   s.registry,
+		httpClient: s.httpClient,
+		username:   s.username,
+		password:   s.password,
+		token:      s.token,
+		insecure:   s.insecure,
+	}, nil
+}
+
+// ociClient is the concrete implementation of ociClientAPI
+type ociClient struct {
+	registry   string
+	httpClient *http.Client
+	username   string
+	password   string
+	token      string
+	insecure   bool
+}
+
+func (c *ociClient) ArtifactExists(ctx context.Context, reference string) (bool, error) {
+	// Parse the reference to get repository and tag
+	repo, tag := c.parseReference(reference)
+	
+	// Check if manifest exists using OCI Distribution API
+	manifestURL := fmt.Sprintf("https://%s/v2/%s/manifests/%s", c.registry, repo, tag)
+	
+	req, err := http.NewRequestWithContext(ctx, "HEAD", manifestURL, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to create request: %w", err)
+	}
+	
+	if c.username != "" && c.password != "" {
+		req.SetBasicAuth(c.username, c.password)
+	}
+	req.Header.Set("Accept", "application/vnd.oci.image.manifest.v1+json")
+	
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("failed to make request: %w", err)
+	}
+	defer resp.Body.Close()
+	
+	if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	} else if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+	
+	return true, nil
+}
+
+func (c *ociClient) DownloadArtifact(ctx context.Context, reference string) ([]byte, error) {
+	// This is a simplified implementation
+	// In a real implementation, you would:
+	// 1. Get the manifest for the reference
+	// 2. Extract blob references from the manifest
+	// 3. Download the actual blob content
+	return nil, fmt.Errorf("download not implemented in this demo")
+}
+
+func (c *ociClient) UploadArtifact(ctx context.Context, reference string, content io.Reader, overwrite bool) error {
+	// This is a simplified implementation
+	// In a real implementation, you would:
+	// 1. Upload blob content
+	// 2. Create and upload manifest
+	return fmt.Errorf("upload not implemented in this demo")
+}
+
+func (c *ociClient) ListTags(ctx context.Context, repository string, callback func(tags []string) error) error {
+	// List tags using OCI Distribution API
+	tagsURL := fmt.Sprintf("https://%s/v2/%s/tags/list", c.registry, repository)
+	
+	req, err := http.NewRequestWithContext(ctx, "GET", tagsURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	
+	if c.username != "" && c.password != "" {
+		req.SetBasicAuth(c.username, c.password)
+	}
+	
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to make request: %w", err)
+	}
+	defer resp.Body.Close()
+	
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+	
+	var result struct {
+		Tags []string `json:"tags"`
+	}
+	
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+	
+	return callback(result.Tags)
+}
+
+func (c *ociClient) GenerateDownloadURL(ctx context.Context, reference string) (string, error) {
+	// For OCI registries, we typically return the reference itself or a proper download URL
+	// This could be enhanced to generate proper registry download URLs based on the registry type
+	return reference, nil
+}
+
+func (c *ociClient) parseReference(reference string) (repository, tag string) {
+	// Simple reference parsing
+	// Format: registry/repository:tag
+	parts := strings.SplitN(reference, "/", 2)
+	if len(parts) < 2 {
+		return reference, "latest"
+	}
+	
+	repoTag := parts[1]
+	tagParts := strings.SplitN(repoTag, ":", 2)
+	if len(tagParts) < 2 {
+		return repoTag, "latest"
+	}
+	
+	return tagParts[0], tagParts[1]
+}

--- a/pkg/storage/oci_test.go
+++ b/pkg/storage/oci_test.go
@@ -1,0 +1,455 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/boring-registry/boring-registry/pkg/core"
+
+	assertion "github.com/stretchr/testify/assert"
+)
+
+type mockOCIClient struct {
+	artifactExists      func(ctx context.Context, reference string) (bool, error)
+	downloadArtifact    func(ctx context.Context, reference string) ([]byte, error)
+	uploadArtifact      func(ctx context.Context, reference string, content io.Reader, overwrite bool) error
+	listTags            func(ctx context.Context, repository string, callback func(tags []string) error) error
+	generateDownloadURL func(ctx context.Context, reference string) (string, error)
+}
+
+func (m *mockOCIClient) ArtifactExists(ctx context.Context, reference string) (bool, error) {
+	if m.artifactExists != nil {
+		return m.artifactExists(ctx, reference)
+	}
+	return true, nil
+}
+
+func (m *mockOCIClient) DownloadArtifact(ctx context.Context, reference string) ([]byte, error) {
+	if m.downloadArtifact != nil {
+		return m.downloadArtifact(ctx, reference)
+	}
+	return nil, nil
+}
+
+func (m *mockOCIClient) UploadArtifact(ctx context.Context, reference string, content io.Reader, overwrite bool) error {
+	if m.uploadArtifact != nil {
+		return m.uploadArtifact(ctx, reference, content, overwrite)
+	}
+	return nil
+}
+
+func (m *mockOCIClient) ListTags(ctx context.Context, repository string, callback func(tags []string) error) error {
+	if m.listTags != nil {
+		return m.listTags(ctx, repository, callback)
+	}
+	return callback([]string{})
+}
+
+func (m *mockOCIClient) GenerateDownloadURL(ctx context.Context, reference string) (string, error) {
+	if m.generateDownloadURL != nil {
+		return m.generateDownloadURL(ctx, reference)
+	}
+	return reference, nil
+}
+
+func artifactExists(ctx context.Context, reference string) (bool, error) {
+	return true, nil
+}
+
+func artifactNotExists(ctx context.Context, reference string) (bool, error) {
+	return false, nil
+}
+
+func TestOCIStorage_UploadProviderReleaseFiles(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		description string
+		namespace   string
+		name        string
+		filename    string
+		content     string
+		client      ociClientAPI
+		wantErr     assertion.ErrorAssertionFunc
+	}{
+		{
+			description: "provider file exists already",
+			namespace:   "hashicorp",
+			name:        "random",
+			filename:    "terraform-provider-random_2.0.0_linux_amd64.zip",
+			client: &mockOCIClient{
+				artifactExists: artifactExists,
+			},
+			wantErr: func(t assertion.TestingT, err error, i ...interface{}) bool {
+				return assertion.Error(t, err)
+			},
+		},
+		{
+			description: "upload file successfully",
+			namespace:   "hashicorp",
+			name:        "random",
+			filename:    "terraform-provider-random_2.0.0_linux_amd64.zip",
+			content:     "test",
+			client: &mockOCIClient{
+				artifactExists: artifactNotExists,
+				uploadArtifact: func(ctx context.Context, reference string, content io.Reader, overwrite bool) error {
+					return nil
+				},
+			},
+			wantErr: func(t assertion.TestingT, err error, i ...interface{}) bool {
+				return assertion.NoError(t, err)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			s := OCIStorage{
+				client:     tc.client,
+				registry:   "registry.example.com",
+				repository: "boring-registry",
+			}
+			err := s.UploadProviderReleaseFiles(context.Background(), tc.namespace, tc.name, tc.filename, strings.NewReader(tc.content))
+			tc.wantErr(t, err)
+		})
+	}
+}
+
+func TestOCISigningKeys(t *testing.T) {
+	var (
+		validGPGPublicKey = core.GPGPublicKey{
+			KeyID:      "51852D87348FFC4C",
+			ASCIIArmor: "-----BEGIN LPGP PUBLIC KEY BLOCK-----\\nVersion: GnuPG v1\\n\\nmQENBFMORM0BCADBRyKO1MhCirazOSVwcfTr1xUxjPvfxD3hjUwHtjsOy/bT6p9f\\nW2mRPfwnq2JB5As+paL3UGDsSRDnK9KAxQb0NNF4+eVhr/EJ18s3wwXXDMjpIifq\\nfIm2WyH3G+aRLTLPIpscUNKDyxFOUbsmgXAmJ46Re1fn8uKxKRHbfa39aeuEYWFA\\n3drdL1WoUngvED7f+RnKBK2G6ZEpO+LDovQk19xGjiMTtPJrjMjZJ3QXqPvx5wca\\nKSZLr4lMTuoTI/ZXyZy5bD4tShiZz6KcyX27cD70q2iRcEZ0poLKHyEIDAi3TM5k\\nSwbbWBFd5RNPOR0qzrb/0p9ksKK48IIfH2FvABEBAAG0K0hhc2hpQ29ycCBTZWN1\\ncml0eSA8c2VjdXJpdHlAaGFzaGljb3JwLmNvbT6JATgEEwECACIFAlMORM0CGwMG\\nCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEFGFLYc0j/xMyWIIAIPhcVqiQ59n\\nJc07gjUX0SWBJAxEG1lKxfzS4Xp+57h2xxTpdotGQ1fZwsihaIqow337YHQI3q0i\\nSqV534Ms+j/tU7X8sq11xFJIeEVG8PASRCwmryUwghFKPlHETQ8jJ+Y8+1asRydi\\npsP3B/5Mjhqv/uOK+Vy3zAyIpyDOMtIpOVfjSpCplVRdtSTFWBu9Em7j5I2HMn1w\\nsJZnJgXKpybpibGiiTtmnFLOwibmprSu04rsnP4ncdC2XRD4wIjoyA+4PKgX3sCO\\nklEzKryWYBmLkJOMDdo52LttP3279s7XrkLEE7ia0fXa2c12EQ0f0DQ1tGUvyVEW\\nWmJVccm5bq25AQ0EUw5EzQEIANaPUY04/g7AmYkOMjaCZ6iTp9hB5Rsj/4ee/ln9\\nwArzRO9+3eejLWh53FoN1rO+su7tiXJA5YAzVy6tuolrqjM8DBztPxdLBbEi4V+j\\n2tK0dATdBQBHEh3OJApO2UBtcjaZBT31zrG9K55D+CrcgIVEHAKY8Cb4kLBkb5wM\\nskn+DrASKU0BNIV1qRsxfiUdQHZfSqtp004nrql1lbFMLFEuiY8FZrkkQ9qduixo\\nmTT6f34/oiY+Jam3zCK7RDN/OjuWheIPGj/Qbx9JuNiwgX6yRj7OE1tjUx6d8g9y\\n0H1fmLJbb3WZZbuuGFnK6qrE3bGeY8+AWaJAZ37wpWh1p0cAEQEAAYkBHwQYAQIA\\nCQUCUw5EzQIbDAAKCRBRhS2HNI/8TJntCAClU7TOO/X053eKF1jqNW4A1qpxctVc\\nz8eTcY8Om5O4f6a/rfxfNFKn9Qyja/OG1xWNobETy7MiMXYjaa8uUx5iFy6kMVaP\\n0BXJ59NLZjMARGw6lVTYDTIvzqqqwLxgliSDfSnqUhubGwvykANPO+93BBx89MRG\\nunNoYGXtPlhNFrAsB1VR8+EyKLv2HQtGCPSFBhrjuzH3gxGibNDDdFQLxxuJWepJ\\nEK1UbTS4ms0NgZ2Uknqn1WRU1Ki7rE4sTy68iZtWpKQXZEJa0IGnuI2sSINGcXCJ\\noEIgXTMyCILo34Fa/C6VCm2WBgz9zZO8/rHIiQm1J5zqz0DrDwKBUM9C\\n=LYpS\\n-----END PGP PUBLIC KEY BLOCK-----",
+			Source:     "HashiCorp",
+			SourceURL:  "https://www.hashicorp.com/security.html",
+		}
+		validSigningKeys = core.SigningKeys{
+			GPGPublicKeys: []core.GPGPublicKey{
+				validGPGPublicKey,
+			},
+		}
+	)
+
+	validSigningKeysBytes, err := json.Marshal(validSigningKeys)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validGPGPublicKeyBytes, err := json.Marshal(validGPGPublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		annotation    string
+		data          map[string][]byte
+		namespace     string
+		returnError   bool
+		expectedError bool
+		expect        core.SigningKeys
+	}{
+		{
+			annotation:    "empty namespace",
+			namespace:     "",
+			expectedError: true,
+			expect:        validSigningKeys,
+		},
+		{
+			annotation: "fetch fails",
+			data: map[string][]byte{
+				"registry.example.com/boring-registry/providers/hashicorp:signing-keys.json": validSigningKeysBytes,
+			},
+			namespace:     "hashicorp",
+			returnError:   true,
+			expectedError: true,
+			expect:        validSigningKeys,
+		},
+		{
+			annotation: "empty object",
+			data: map[string][]byte{
+				"registry.example.com/boring-registry/providers/hashicorp:signing-keys.json": []byte(""),
+			},
+			namespace:     "hashicorp",
+			expectedError: true,
+			expect:        validSigningKeys,
+		},
+		{
+			annotation: "only single gpg_public_key for the provider namespace",
+			data: map[string][]byte{
+				"registry.example.com/boring-registry/providers/hashicorp:signing-keys.json": validGPGPublicKeyBytes,
+			},
+			namespace:     "hashicorp",
+			expectedError: false,
+			expect:        validSigningKeys,
+		},
+		{
+			annotation: "signing_keys with a single gpg_public_key",
+			data: map[string][]byte{
+				"registry.example.com/boring-registry/providers/hashicorp:signing-keys.json": validSigningKeysBytes,
+			},
+			namespace:     "hashicorp",
+			expectedError: false,
+			expect:        validSigningKeys,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.annotation, func(t *testing.T) {
+			s := OCIStorage{
+				registry:   "registry.example.com",
+				repository: "boring-registry",
+				client: &mockOCIClient{
+					artifactExists: func(ctx context.Context, reference string) (bool, error) {
+						return !tc.returnError, nil
+					},
+					downloadArtifact: func(ctx context.Context, reference string) ([]byte, error) {
+						if tc.returnError {
+							return nil, errors.New("fetch error")
+						}
+						if data, exists := tc.data[reference]; exists {
+							return data, nil
+						}
+						return nil, errors.New("not found")
+					},
+				},
+			}
+
+			result, err := s.SigningKeys(context.Background(), tc.namespace)
+
+			if !tc.expectedError {
+				assertion.NoError(t, err)
+			} else {
+				assertion.Error(t, err)
+				return
+			}
+
+			assertion.Equal(t, &tc.expect, result)
+		})
+	}
+}
+
+func TestOCIStorage_getProvider(t *testing.T) {
+	type fields struct {
+		client ociClientAPI
+	}
+	type args struct {
+		pt       providerType
+		provider *core.Provider
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *core.Provider
+		wantErr bool
+	}{
+		{
+			name: "provider does not exist",
+			fields: fields{
+				client: &mockOCIClient{
+					artifactExists: artifactNotExists,
+				},
+			},
+			args: args{
+				pt: internalProviderType,
+				provider: &core.Provider{
+					Namespace: "example",
+					Name:      "dummy",
+					Version:   "1.0.0",
+					OS:        "linux",
+					Arch:      "amd64",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "internal provider exists",
+			fields: fields{
+				client: &mockOCIClient{
+					artifactExists: artifactExists,
+					generateDownloadURL: func(ctx context.Context, reference string) (string, error) {
+						return reference, nil
+					},
+					downloadArtifact: func(ctx context.Context, reference string) ([]byte, error) {
+						if strings.Contains(reference, "SHA256SUMS") && !strings.Contains(reference, ".sig") {
+							return []byte("10488a12525ed674359585f83e3ee5e74818b5c98e033798351678b21b2f7d89  terraform-provider-dummy_1.0.0_linux_amd64.zip"), nil
+						}
+						if strings.Contains(reference, "signing-keys.json") {
+							return []byte(`{"gpg_public_keys":[{"key_id":"47422B4AA9FA381B","ascii_armor":"test"}]}`), nil
+						}
+						return nil, nil
+					},
+				},
+			},
+			args: args{
+				pt: internalProviderType,
+				provider: &core.Provider{
+					Namespace: "example",
+					Name:      "dummy",
+					Version:   "1.0.0",
+					OS:        "linux",
+					Arch:      "amd64",
+				},
+			},
+			want: &core.Provider{
+				Namespace:           "example",
+				Name:                "dummy",
+				Version:             "1.0.0",
+				OS:                  "linux",
+				Arch:                "amd64",
+				Filename:            "terraform-provider-dummy_1.0.0_linux_amd64.zip",
+				DownloadURL:         "registry.example.com/boring-registry/providers/example/dummy:terraform-provider-dummy_1.0.0_linux_amd64.zip",
+				Shasum:              "10488a12525ed674359585f83e3ee5e74818b5c98e033798351678b21b2f7d89",
+				SHASumsURL:          "registry.example.com/boring-registry/providers/example/dummy:terraform-provider-dummy_1.0.0_SHA256SUMS",
+				SHASumsSignatureURL: "registry.example.com/boring-registry/providers/example/dummy:terraform-provider-dummy_1.0.0_SHA256SUMS.sig",
+				SigningKeys: core.SigningKeys{
+					GPGPublicKeys: []core.GPGPublicKey{
+						{
+							KeyID:      "47422B4AA9FA381B",
+							ASCIIArmor: "test",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "mirrored provider exists",
+			fields: fields{
+				client: &mockOCIClient{
+					artifactExists: artifactExists,
+					generateDownloadURL: func(ctx context.Context, reference string) (string, error) {
+						return reference, nil
+					},
+					downloadArtifact: func(ctx context.Context, reference string) ([]byte, error) {
+						if strings.Contains(reference, "SHA256SUMS") && !strings.Contains(reference, ".sig") {
+							return []byte("10488a12525ed674359585f83e3ee5e74818b5c98e033798351678b21b2f7d89  terraform-provider-dummy_1.0.0_linux_amd64.zip"), nil
+						}
+						if strings.Contains(reference, "signing-keys.json") {
+							return []byte(`{"gpg_public_keys":[{"key_id":"47422B4AA9FA381B","ascii_armor":"test"}]}`), nil
+						}
+						return nil, nil
+					},
+				},
+			},
+			args: args{
+				pt: mirrorProviderType,
+				provider: &core.Provider{
+					Hostname:  "terraform.example.com",
+					Namespace: "example",
+					Name:      "dummy",
+					Version:   "1.0.0",
+					OS:        "linux",
+					Arch:      "amd64",
+				},
+			},
+			want: &core.Provider{
+				Hostname:            "terraform.example.com",
+				Namespace:           "example",
+				Name:                "dummy",
+				Version:             "1.0.0",
+				OS:                  "linux",
+				Arch:                "amd64",
+				Filename:            "terraform-provider-dummy_1.0.0_linux_amd64.zip",
+				DownloadURL:         "registry.example.com/boring-registry/mirror/providers/terraform.example.com/example/dummy:terraform-provider-dummy_1.0.0_linux_amd64.zip",
+				Shasum:              "10488a12525ed674359585f83e3ee5e74818b5c98e033798351678b21b2f7d89",
+				SHASumsURL:          "registry.example.com/boring-registry/mirror/providers/terraform.example.com/example/dummy:terraform-provider-dummy_1.0.0_SHA256SUMS",
+				SHASumsSignatureURL: "registry.example.com/boring-registry/mirror/providers/terraform.example.com/example/dummy:terraform-provider-dummy_1.0.0_SHA256SUMS.sig",
+				SigningKeys: core.SigningKeys{
+					GPGPublicKeys: []core.GPGPublicKey{
+						{
+							KeyID:      "47422B4AA9FA381B",
+							ASCIIArmor: "test",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &OCIStorage{
+				registry:   "registry.example.com",
+				repository: "boring-registry",
+				client:     tt.fields.client,
+			}
+			got, err := s.getProvider(context.Background(), tt.args.pt, tt.args.provider)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("OCIStorage.getProvider() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("OCIStorage.getProvider() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOCIStorage_GetModule(t *testing.T) {
+	tests := []struct {
+		name        string
+		client      ociClientAPI
+		namespace   string
+		moduleName  string
+		provider    string
+		version     string
+		want        core.Module
+		wantErr     bool
+	}{
+		{
+			name: "module exists",
+			client: &mockOCIClient{
+				artifactExists: artifactExists,
+				generateDownloadURL: func(ctx context.Context, reference string) (string, error) {
+					return reference, nil
+				},
+			},
+			namespace:  "example",
+			moduleName: "mymodule",
+			provider:   "aws",
+			version:    "1.0.0",
+			want: core.Module{
+				Namespace:   "example",
+				Name:        "mymodule",
+				Provider:    "aws",
+				Version:     "1.0.0",
+				DownloadURL: "registry.example.com/boring-registry/modules/example/mymodule/aws:example-mymodule-aws-1.0.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "module does not exist",
+			client: &mockOCIClient{
+				artifactExists: artifactNotExists,
+			},
+			namespace:  "example",
+			moduleName: "mymodule",
+			provider:   "aws",
+			version:    "1.0.0",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &OCIStorage{
+				registry:   "registry.example.com",
+				repository: "boring-registry",
+				client:     tt.client,
+			}
+			got, err := s.GetModule(context.Background(), tt.namespace, tt.moduleName, tt.provider, tt.version)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("OCIStorage.GetModule() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("OCIStorage.GetModule() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adding support for OCI backends

That helps us save $ by using a free provider like ghcr or docker, instead of AWS/GPC/Azure, also move the needle forward for more OCI adoption
[still untested]